### PR TITLE
Refactor(rust_system): Use git dependency for wgpu_rt_lidar

### DIFF
--- a/src/rust_system/Cargo.toml
+++ b/src/rust_system/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-wgpu_rt_lidar = { path="/home/arjo/ws/wgpu_src/wgpu_rt_lidar" }
+wgpu_rt_lidar = { git = "https://github.com/arjo129/wgpu_rt_lidar.git" , rev = "cf51542434b94fe62e11e72a2d98b04938c33b5e"}
 wgpu = { git = "https://github.com/gfx-rs/wgpu", rev = "e86ed8b6c858451fa6da212dc9835730ad4da826" }
 glam = { version = "0.29.2", features = ["bytemuck"] }
 futures="0.3.31"


### PR DESCRIPTION
Switches from a hard-coded local path dependency to a git dependency for wgpu_rt_lidar to simplify the build process.