### PR TITLE
Fix/depthcamera arguments

### DIFF
--- a/src/rust_system/Cargo.toml
+++ b/src/rust_system/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-wgpu_rt_lidar = { path="/home/arjo/ws/wgpu_src/wgpu_rt_lidar" }
+wgpu_rt_lidar = { git = "https://github.com/arjo129/wgpu_rt_lidar.git" , rev = "cf51542434b94fe62e11e72a2d98b04938c33b5e"}
 wgpu = { git = "https://github.com/gfx-rs/wgpu", rev = "e86ed8b6c858451fa6da212dc9835730ad4da826" }
 glam = { version = "0.29.2", features = ["bytemuck"] }
 futures="0.3.31"

--- a/src/rust_system/src/lib.rs
+++ b/src/rust_system/src/lib.rs
@@ -303,7 +303,7 @@ pub extern "C" fn create_rt_depth_camera(runtime: *mut RtRuntime, width: u32, he
         &mut *runtime
     };
 
-    let camera = wgpu_rt_lidar::depth_camera::DepthCamera::new(&runtime.device, width, height, fov, 50.0);
+    let camera = wgpu_rt_lidar::depth_camera::DepthCamera::new(&runtime.device, width, height, fov);
     Box::into_raw(Box::new(RtDepthCamera {
         camera: futures::executor::block_on(camera)
     }))


### PR DESCRIPTION
Fix(rust_system): Correct arguments for DepthCamera::new() call

Adjusts the function call (removed argument- 50.0) to match the API of the wgpu_rt_lidar
dependency, resolving an E0061 compilation error related to
the number of arguments.