### PR TITLE
Feat: Added custom sensor support by merging it into the main plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,8 @@ corrosion_import_crate(MANIFEST_PATH src/rust_system/Cargo.toml)
 #============================================================================
 # Wrapper stuff
 add_library(wgpu_rt_sensor SHARED
-  src/wgpu_sensor.cc)
+  src/wgpu_sensor.cc
+  src/rtsensor.cc)
 
 target_link_libraries(wgpu_rt_sensor PUBLIC
         rust_system

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ find_package(gz_common_vendor REQUIRED)
 find_package(gz-common REQUIRED COMPONENTS graphics)
 find_package(gz_math_vendor REQUIRED)
 find_package(gz-math REQUIRED)
+find_package(gz_sensors_vendor REQUIRED)
+find_package(gz-sensors REQUIRED)
 
 #============================================================================
 # Corrosion
@@ -49,10 +51,11 @@ add_library(wgpu_rt_sensor SHARED
 
 target_link_libraries(wgpu_rt_sensor PUBLIC
         rust_system
-        gz-plugin${GZ_PLUGIN_VER}::gz-plugin${GZ_PLUGIN_VER}
-        gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
+        gz-plugin::gz-plugin
+        gz-sim::gz-sim
         gz-common::graphics
         gz-math::gz-math
+        gz-sensors::gz-sensors
 )
 
 install(TARGETS wgpu_rt_sensor DESTINATION lib)

--- a/examples/custom.sdf
+++ b/examples/custom.sdf
@@ -5,6 +5,12 @@
     <plugin
       filename="wgpu_rt_sensor" name="wgpu_sensor::WGPURtSensor"/>
 
+    <plugin filename="gz-sim-physics-system"
+            name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin filename="gz-sim-user-commands-system"
+            name="gz::sim::systems::UserCommands">
+    </plugin>
     <plugin
       filename="gz-sim-scene-broadcaster-system"
       name="gz::sim::systems::SceneBroadcaster"/>

--- a/examples/custom.sdf
+++ b/examples/custom.sdf
@@ -1,0 +1,139 @@
+<?xml version="1.0" ?>
+<sdf version="1.11">
+  <world name="shapes">
+
+    <plugin
+      filename="wgpu_rt_sensor" name="wgpu_sensor::WGPURtSensor"/>
+
+    <plugin
+      filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster"/>
+
+    <scene>
+      <ambient>1.0 1.0 1.0</ambient>
+      <background>0.8 0.8 0.8</background>
+    </scene>
+
+    <physics name="1ms" type="dart">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>0</real_time_factor>
+    </physics>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="camera">
+      <pose>0 0 6.0 0 0 0</pose>
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>0.1 0.1</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>0.1 0.1</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.0 0.8 1</ambient>
+            <diffuse>0.8 0.0 0.8 1</diffuse>
+            <specular>0.8 0.0 0.8 1</specular>
+          </material>
+        </visual>
+
+        <!-- Custom Camera Sensor -->
+        <sensor name="my_rt_camera" type="custom" gz:type="rt_camera">
+          <pose>0 0 0.1 0 0 0</pose> <!-- Local pose relative to this link -->
+          <always_on>1</always_on>
+          <update_rate>10</update_rate>
+          <gz:rt_camera>
+            <fov>1.047</fov> <!-- Example FOV: 60 degrees -->
+          </gz:rt_camera>
+        </sensor>
+      </link>
+    </model>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>20 20</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>20 20</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="box">
+      <pose>0 0 0.8 0 0 0</pose>
+      <link name="box_link">
+        <inertial>
+          <inertia>
+            <ixx>0.16666</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.16666</iyy>
+            <iyz>0</iyz>
+            <izz>0.16666</izz>
+          </inertia>
+          <mass>1.0</mass>
+        </inertial>
+        <collision name="box_collision">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+
+        <visual name="box_visual">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>1 0 0 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>

--- a/src/rtsensor.cc
+++ b/src/rtsensor.cc
@@ -1,0 +1,200 @@
+#include <gz/plugin/Register.hh>
+#include <gz/common/Console.hh>
+#include <gz/sensors/Sensor.hh>
+#include <gz/sensors/SensorFactory.hh>
+#include <gz/math/Pose3.hh>
+#include <sdf/Element.hh>
+#include <string>
+#include <chrono>
+
+namespace rtsensor
+{
+  class RtSensor : public gz::sensors::Sensor
+  {
+    /// \brief Sensor type enumeration.
+    public: enum class SensorType
+    {
+      CAMERA,
+      LIDAR
+    };
+
+    /// \brief Constructor.
+    public: RtSensor();
+
+    /// \brief Destructor.
+    public: ~RtSensor();
+
+    /// \brief Load the sensor with SDF parameters.
+    public: bool Load(const sdf::Sensor &_sdf) override;
+
+    /// \brief Update the sensor and generate data.
+    public: bool Update(
+      const std::chrono::steady_clock::duration &_now) override;
+
+    /// \brief Set the current pose of the sensor in world coordinates.
+    public: void SetPose(const gz::math::Pose3d &_pose);
+
+    /// \brief Get the latest world pose of the sensor.
+    public: const gz::math::Pose3d &Pose() const;
+
+    /// \brief Get the sensor type.
+    public: SensorType Type() const;
+
+    /// \brief Get the Field of View (FOV) configured for the sensor.
+    public: double FOV() const;
+
+    /// \brief Set the name of the parent entity (e.g., link or model) this sensor is attached to.
+    public: void SetParentEntityName(const std::string& _parentName);
+
+    /// \brief Get the name of the parent entity.
+    public: const std::string& ParentEntityName() const;
+
+    /// \brief Sensor type (camera or lidar).
+    private: SensorType sensorType{SensorType::CAMERA};
+
+    /// \brief Current sensor pose in world coordinates.
+    private: gz::math::Pose3d currentPose{gz::math::Pose3d::Zero};
+
+    /// \brief Field of View for the sensor (camera or lidar).
+    private: double fov{1.047}; // Default FOV (approx 60 degrees)
+
+    /// \brief The name of the parent entity (model or link) this sensor is attached to.
+    private: std::string parentEntityName;
+  };
+
+  //////////////////////////////////////////////////
+  RtSensor::RtSensor()
+  {
+    gzdbg << "[RtSensor] Constructor called" << std::endl;
+  }
+
+  //////////////////////////////////////////////////
+  RtSensor::~RtSensor()
+  {
+    gzdbg << "[RtSensor] Destructor called" << std::endl;
+  }
+
+  //////////////////////////////////////////////////
+  bool RtSensor::Load(const sdf::Sensor &_sdf)
+  {
+    gzdbg << "[RtSensor] Loading sensor configuration" << std::endl;
+
+    // Load base sensor properties inherited from gz::sensors::Sensor
+    if (!gz::sensors::Sensor::Load(_sdf))
+    {
+      gzerr << "[RtSensor] Failed to load base sensor properties" << std::endl;
+      return false;
+    }
+
+    // Get the custom sensor type from SDF.
+    // This is expected to be defined as <sensor type="custom" gz:type="rt_camera"> or "rt_lidar"
+    std::string customType;
+    if (_sdf.Element()->HasAttribute("gz:type"))
+    {
+      customType = _sdf.Element()->Get<std::string>("gz:type");
+    }
+    else
+    {
+      gzerr << "[RtSensor] Missing 'gz:type' attribute for custom sensor." << std::endl;
+      return false;
+    }
+
+    gzdbg << "[RtSensor] Detected custom sensor type: " << customType << std::endl;
+
+    // Determine sensor type and parse type-specific parameters
+    if (customType == "rt_lidar")
+    {
+      this->sensorType = SensorType::LIDAR;
+      // Parse LiDAR specific configuration
+      auto lidarElement = _sdf.Element()->FindElement("gz:rt_lidar");
+      if (lidarElement)
+      {
+        if (lidarElement->HasElement("fov"))
+        {
+          this->fov = lidarElement->Get<double>("fov");
+          gzdbg << "[RtSensor] LiDAR FOV set to: " << this->fov << std::endl;
+        }
+      }
+    }
+    else if (customType == "rt_camera")
+    {
+      this->sensorType = SensorType::CAMERA;
+      // Parse Camera specific configuration
+      auto cameraElement = _sdf.Element()->FindElement("gz:rt_camera");
+      if (cameraElement)
+      {
+        if (cameraElement->HasElement("fov"))
+        {
+          this->fov = cameraElement->Get<double>("fov");
+          gzdbg << "[RtSensor] Camera FOV set to: " << this->fov << std::endl;
+        }
+      }
+    }
+    else
+    {
+      gzerr << "[RtSensor] Unknown custom sensor type: [" << customType << "]" << std::endl;
+      return false;
+    }
+
+    gzmsg << "[RtSensor] Successfully loaded sensor [" << this->Name() << "] of type ["
+          << (this->sensorType == SensorType::LIDAR ? "LIDAR" : "CAMERA")
+          << "], FOV: [" << this->fov << "]" << std::endl;
+    return true;
+  }
+
+  //////////////////////////////////////////////////
+  bool RtSensor::Update(const std::chrono::steady_clock::duration &_now)
+  {
+    // For RtSensor, the actual rendering and data generation is handled by the
+    // WGPURtSensor system plugin. This method is primarily here to fulfill the
+    // base class requirement and can be used for any internal sensor state updates.
+    // We can add more specific update logic here if needed for the sensor itself,
+    // independent of the WGPU rendering.
+    gzdbg << "[RtSensor] Update called for sensor [" << this->Name() << "] at sim time: "
+          << std::chrono::duration_cast<std::chrono::milliseconds>(_now).count() << "ms" << std::endl;
+    return true;
+  }
+
+  //////////////////////////////////////////////////
+  void RtSensor::SetParentEntityName(const std::string& _parentName)
+  {
+    this->parentEntityName = _parentName;
+  }
+
+  //////////////////////////////////////////////////
+  const std::string& RtSensor::ParentEntityName() const
+  {
+    return this->parentEntityName;
+  }
+
+  //////////////////////////////////////////////////
+  RtSensor::SensorType RtSensor::Type() const
+  {
+    return this->sensorType;
+  }
+
+  //////////////////////////////////////////////////
+  double RtSensor::FOV() const
+  {
+    return this->fov;
+  }
+
+  //////////////////////////////////////////////////
+  const gz::math::Pose3d &RtSensor::Pose() const
+  {
+    return this->currentPose;
+  }
+
+  //////////////////////////////////////////////////
+  void RtSensor::SetPose(const gz::math::Pose3d &_pose)
+  {
+    this->currentPose = _pose;
+  }
+
+} // namespace rtsensor
+
+
+GZ_ADD_PLUGIN(rtsensor::RtSensor, gz::sensors::Sensor)
+
+
+GZ_ADD_PLUGIN_ALIAS(rtsensor::RtSensor, "rtsensor::RtSensor")

--- a/src/rtsensor.cc
+++ b/src/rtsensor.cc
@@ -1,66 +1,13 @@
-#include <gz/plugin/Register.hh>
 #include <gz/common/Console.hh>
 #include <gz/sensors/Sensor.hh>
 #include <gz/sensors/SensorFactory.hh>
 #include <gz/math/Pose3.hh>
 #include <sdf/Element.hh>
 #include <string>
-#include <chrono>
 
-namespace rtsensor
-{
-  class RtSensor : public gz::sensors::Sensor
-  {
-    /// \brief Sensor type enumeration.
-    public: enum class SensorType
-    {
-      CAMERA,
-      LIDAR
-    };
+#include "rtsensor.hh"
 
-    /// \brief Constructor.
-    public: RtSensor();
-
-    /// \brief Destructor.
-    public: ~RtSensor();
-
-    /// \brief Load the sensor with SDF parameters.
-    public: bool Load(const sdf::Sensor &_sdf) override;
-
-    /// \brief Update the sensor and generate data.
-    public: bool Update(
-      const std::chrono::steady_clock::duration &_now) override;
-
-    /// \brief Set the current pose of the sensor in world coordinates.
-    public: void SetPose(const gz::math::Pose3d &_pose);
-
-    /// \brief Get the latest world pose of the sensor.
-    public: const gz::math::Pose3d &Pose() const;
-
-    /// \brief Get the sensor type.
-    public: SensorType Type() const;
-
-    /// \brief Get the Field of View (FOV) configured for the sensor.
-    public: double FOV() const;
-
-    /// \brief Set the name of the parent entity (e.g., link or model) this sensor is attached to.
-    public: void SetParentEntityName(const std::string& _parentName);
-
-    /// \brief Get the name of the parent entity.
-    public: const std::string& ParentEntityName() const;
-
-    /// \brief Sensor type (camera or lidar).
-    private: SensorType sensorType{SensorType::CAMERA};
-
-    /// \brief Current sensor pose in world coordinates.
-    private: gz::math::Pose3d currentPose{gz::math::Pose3d::Zero};
-
-    /// \brief Field of View for the sensor (camera or lidar).
-    private: double fov{1.047}; // Default FOV (approx 60 degrees)
-
-    /// \brief The name of the parent entity (model or link) this sensor is attached to.
-    private: std::string parentEntityName;
-  };
+using namespace rtsensor;
 
   //////////////////////////////////////////////////
   RtSensor::RtSensor()
@@ -145,11 +92,6 @@ namespace rtsensor
   //////////////////////////////////////////////////
   bool RtSensor::Update(const std::chrono::steady_clock::duration &_now)
   {
-    // For RtSensor, the actual rendering and data generation is handled by the
-    // WGPURtSensor system plugin. This method is primarily here to fulfill the
-    // base class requirement and can be used for any internal sensor state updates.
-    // We can add more specific update logic here if needed for the sensor itself,
-    // independent of the WGPU rendering.
     gzdbg << "[RtSensor] Update called for sensor [" << this->Name() << "] at sim time: "
           << std::chrono::duration_cast<std::chrono::milliseconds>(_now).count() << "ms" << std::endl;
     return true;
@@ -190,11 +132,3 @@ namespace rtsensor
   {
     this->currentPose = _pose;
   }
-
-} // namespace rtsensor
-
-
-GZ_ADD_PLUGIN(rtsensor::RtSensor, gz::sensors::Sensor)
-
-
-GZ_ADD_PLUGIN_ALIAS(rtsensor::RtSensor, "rtsensor::RtSensor")

--- a/src/rtsensor.hh
+++ b/src/rtsensor.hh
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <gz/sensors/Sensor.hh>
+#include <gz/math/Pose3.hh>
+#include <string>
+#include <sdf/Sensor.hh>
+
+namespace rtsensor
+{
+  /// \brief Simple abstract RT sensor that can be configured as camera or lidar.
+  /// This class defines the properties and basic behavior of a custom raytracing sensor.
+  class RtSensor : public gz::sensors::Sensor
+  {
+    /// \brief Sensor type enumeration.
+    public: enum class SensorType
+    {
+      CAMERA,
+      LIDAR
+    };
+
+    /// \brief Constructor.
+    public: RtSensor();
+
+    /// \brief Destructor.
+    public: virtual ~RtSensor();
+
+    /// \brief Load the sensor with SDF parameters.
+    public: bool Load(const sdf::Sensor &_sdf) override;
+
+    /// \brief Update the sensor and generate data.
+    public: bool Update(
+      const std::chrono::steady_clock::duration &_now) override;
+
+    /// \brief Set the current pose of the sensor in world coordinates.
+    public: void SetPose(const gz::math::Pose3d &_pose);
+
+    /// \brief Get the latest world pose of the sensor.
+    public: const gz::math::Pose3d &Pose() const;
+
+    /// \brief Get the sensor type.
+    public: SensorType Type() const;
+
+    /// \brief Get the Field of View (FOV) configured for the sensor.
+    public: double FOV() const;
+
+    /// \brief Set the name of the parent entity (e.g., link or model) this sensor is attached to.
+    public: void SetParentEntityName(const std::string& _parentName);
+
+    /// \brief Get the name of the parent entity.
+    public: const std::string& ParentEntityName() const;
+
+    /// \brief Sensor type (camera or lidar).
+    private: SensorType sensorType{SensorType::CAMERA};
+
+    /// \brief Current sensor pose in world coordinates.
+    private: gz::math::Pose3d currentPose{gz::math::Pose3d::Zero};
+
+    /// \brief Field of View for the sensor (camera or lidar).
+    private: double fov{1.047}; // Default FOV (approx 60 degrees)
+
+    /// \brief The name of the parent entity (model or link) this sensor is attached to.
+    private: std::string parentEntityName;
+  };
+}

--- a/src/wgpu_sensor.cc
+++ b/src/wgpu_sensor.cc
@@ -5,6 +5,9 @@
 #include <gz/sim/components/Pose.hh>
 #include <gz/sim/components/Geometry.hh>
 #include <gz/sim/components/Visual.hh>
+#include <gz/sim/components/CustomSensor.hh>
+#include <gz/sim/components/ParentEntity.hh>
+#include <gz/sim/components/Name.hh>
 #include <gz/sim/System.hh>
 #include <gz/sim/Util.hh>
 
@@ -17,8 +20,14 @@
 
 #include <sdf/Box.hh>
 #include <sdf/Plane.hh>
+#include <sdf/Sensor.hh>
+#include <unordered_map>
+#include <memory>
+#include <string>
 
 #include "rust_binding.h"
+
+#include "rtsensor.cc"
 
 namespace wgpu_sensor
 {
@@ -26,6 +35,7 @@ namespace wgpu_sensor
   class WGPURtSensor :
     public gz::sim::System,
     public gz::sim::ISystemConfigure,
+    public gz::sim::ISystemPreUpdate,
     public gz::sim::ISystemPostUpdate
   {
     /// \brief Constructor
@@ -39,9 +49,16 @@ namespace wgpu_sensor
                            gz::sim::EntityComponentManager &_ecm,
                            gz::sim::EventManager &_eventMgr) override;
 
+    public: void PreUpdate(const gz::sim::UpdateInfo &_info,
+                           gz::sim::EntityComponentManager &_ecm) override;
+
     // Documentation inherited
     public: void PostUpdate(const gz::sim::UpdateInfo &_info,
                             const gz::sim::EntityComponentManager &_ecm) override;
+
+    public: void RemoveSensorEntities(const gz::sim::EntityComponentManager &_ecm);
+
+    private: Mesh* convertSDFModelToWGPU(const sdf::Geometry& geom);
 
     RtScene* rt_scene {nullptr};
     RtRuntime* rt_runtime;
@@ -49,6 +66,7 @@ namespace wgpu_sensor
     std::unordered_map<size_t, size_t> gz_entity_to_rt_instance;
     gz::sim::Entity camera_entity;
     std::chrono::steady_clock::duration last_time;
+    std::unordered_map<gz::sim::Entity, std::shared_ptr<rtsensor::RtSensor>> entitySensorMap;
   };
 
   WGPURtSensor::WGPURtSensor() {}
@@ -66,7 +84,7 @@ namespace wgpu_sensor
     free_rt_runtime(rt_runtime);
   }
 
-  Mesh* convertSDFModelToWGPU(const sdf::Geometry& geom)
+  Mesh* WGPURtSensor::convertSDFModelToWGPU(const sdf::Geometry& geom)
   {
     if (geom.Type() == sdf::GeometryType::BOX)
     {
@@ -218,6 +236,59 @@ namespace wgpu_sensor
     this->camera_entity = _entity;
   }
 
+  void WGPURtSensor::PreUpdate(const gz::sim::UpdateInfo &_info,
+                               gz::sim::EntityComponentManager &_ecm)
+  {
+    // Detect new custom sensors and create RtSensor instances for them
+    _ecm.EachNew<gz::sim::components::CustomSensor,
+                 gz::sim::components::ParentEntity>(
+      [&](const gz::sim::Entity &_entity,
+          const gz::sim::components::CustomSensor *_custom,
+          const gz::sim::components::ParentEntity *_parent) -> bool
+      {
+        // Get the sensor's scoped name (e.g., "world_name::model_name::link_name::sensor_name")
+        // Remove world scope for cleaner names if needed for internal logic
+        auto sensorScopedName = gz::sim::removeParentScope(
+            gz::sim::scopedName(_entity, _ecm, "::", false), "::");
+        sdf::Sensor data = _custom->Data();
+        data.SetName(sensorScopedName); // Ensure SDF data has the correct name
+
+        // If the sensor topic is not explicitly set in SDF, generate a default one
+        if (data.Topic().empty())
+        {
+          std::string topic = gz::sim::scopedName(_entity, _ecm) + "/rt_sensor";
+          data.SetTopic(topic);
+        }
+
+        // Create an instance of our custom RtSensor
+        auto sensor = std::make_shared<rtsensor::RtSensor>();
+        if (!sensor->Load(data))
+        {
+          gzerr << "[WGPURtSensor] Failed to load RtSensor for entity ["
+                << _entity << "] with name [" << sensorScopedName << "]" << std::endl;
+          return false;
+        }
+
+        // Set the parent entity name on the RtSensor instance for later pose lookup
+        auto parentNameComp = _ecm.Component<gz::sim::components::Name>(_parent->Data());
+        if (parentNameComp)
+        {
+          sensor->SetParentEntityName(parentNameComp->Data());
+        }
+        else
+        {
+          gzerr << "[WGPURtSensor] Parent entity name not found for sensor entity [" << _entity << "]" << std::endl;
+        }
+
+        // Store the new sensor in our map
+        this->entitySensorMap.insert(std::make_pair(_entity, std::move(sensor)));
+        gzmsg << "[WGPURtSensor] Registered new custom sensor for entity ["
+              << _entity << "] named [" << sensorScopedName << "]" << std::endl;
+        return true;
+      });
+  }
+
+
   void WGPURtSensor::PostUpdate(const gz::sim::UpdateInfo &_info,
                                 const gz::sim::EntityComponentManager &_ecm)
   {
@@ -294,6 +365,8 @@ namespace wgpu_sensor
 
       set_transforms(rt_scene, rt_runtime, rt_scene_update);
 
+      // Old camera rendering code
+      /*
       auto camera_pose = gz::sim::worldPose(camera_entity, _ecm);
       auto view_matrix = create_view_matrix(camera_pose.Pos().X(), camera_pose.Pos().Y(), camera_pose.Pos().Z(), camera_pose.Rot().X(), camera_pose.Rot().Y(), camera_pose.Rot().Z(), camera_pose.Rot().W());
       render_depth(rt_depth_camera, rt_scene, rt_runtime, view_matrix);
@@ -301,12 +374,92 @@ namespace wgpu_sensor
       free_view_matrix(view_matrix);
       high_resolution_clock::time_point t2 = high_resolution_clock::now();
       auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count();
-      gzmsg << "Time taken to render depth: " << duration << std::endl;
+      gzmsg << "Time taken to render depth: " << duration << std::endl; */
+
+      for (auto const& [entityId, sensor] : this->entitySensorMap)
+      {
+        // Find the parent entity's pose to get the sensor's world pose
+        // (assuming the sensor's pose is relative to its parent link/model)
+        gz::sim::Entity parentEntity = gz::sim::kNullEntity;
+        _ecm.Each<gz::sim::components::Name>(
+            [&](const gz::sim::Entity &ent, const gz::sim::components::Name *name)
+            {
+                if (name->Data() == sensor->ParentEntityName())
+                {
+                    parentEntity = ent;
+                    return false; // Found, stop iteration
+                }
+                return true;
+            });
+
+        if (parentEntity != gz::sim::kNullEntity)
+        {
+          // Get the world pose of the parent entity
+          auto sensor_world_pose = gz::sim::worldPose(parentEntity, _ecm);
+          auto view_matrix = create_view_matrix(
+            static_cast<float>(sensor_world_pose.Pos().X()), static_cast<float>(sensor_world_pose.Pos().Y()), static_cast<float>(sensor_world_pose.Pos().Z()),
+            static_cast<float>(sensor_world_pose.Rot().X()), static_cast<float>(sensor_world_pose.Rot().Y()), static_cast<float>(sensor_world_pose.Rot().Z()), static_cast<float>(sensor_world_pose.Rot().W()));
+
+          render_depth(this->rt_depth_camera, this->rt_scene, this->rt_runtime, view_matrix);
+          free_view_matrix(view_matrix);
+          gzdbg << "[WGPURtSensor] Rendered from custom sensor [" << sensor->Name() << "]" << std::endl;
+        }
+        else
+        {
+          gzwarn << "[WGPURtSensor] Could not find parent entity [" << sensor->ParentEntityName()
+                 << "] for custom sensor [" << sensor->Name() << "], skipping render." << std::endl;
+        }
+      }
+
+      free_rt_scene_update(rt_scene_update); // Free the update object
     }
+
+    // --- Update Custom Sensors ---
+    if (!_info.paused)
+    {
+      for (auto &[entity, sensor] : this->entitySensorMap)
+      {
+        auto baseSensor = std::dynamic_pointer_cast<gz::sensors::Sensor>(sensor);
+        if (baseSensor)
+        {
+          baseSensor->Update(_info.simTime, false); // false to respect update rate
+        }
+        else
+        {
+          sensor->Update(_info.simTime);
+          gzerr << "[WGPURtSensor] Error casting custom sensor to base Sensor class." << std::endl;
+        }
+	  }
+    }
+    // --- Remove Sensors ---
+    this->RemoveSensorEntities(_ecm);
+  }
+  void WGPURtSensor::RemoveSensorEntities(
+      const gz::sim::EntityComponentManager &_ecm)
+  {
+    //GZ_PROFILE("WGPURtSensor::RemoveSensorEntities");
+
+    // Iterate over entities that have been removed and clear them from our map
+    _ecm.EachRemoved<gz::sim::components::CustomSensor>(
+      [&](const gz::sim::Entity &_entity,
+          const gz::sim::components::CustomSensor *) -> bool
+      {
+        if (this->entitySensorMap.erase(_entity) == 0)
+        {
+          gzerr << "[WGPURtSensor] Internal error: tried to remove RtSensor for entity ["
+                << _entity << "] but it was not found in map." << std::endl;
+        }
+        else
+        {
+          gzmsg << "[WGPURtSensor] Removed RtSensor for entity [" << _entity << "]." << std::endl;
+        }
+        return true;
+      });
   }
 }
 
 GZ_ADD_PLUGIN(wgpu_sensor::WGPURtSensor,
               gz::sim::System,
               gz::sim::ISystemConfigure,
+              gz::sim::ISystemPreUpdate,
               gz::sim::ISystemPostUpdate)

--- a/src/wgpu_sensor.cc
+++ b/src/wgpu_sensor.cc
@@ -27,7 +27,7 @@
 
 #include "rust_binding.h"
 
-#include "rtsensor.cc"
+#include "rtsensor.hh"
 
 namespace wgpu_sensor
 {
@@ -58,7 +58,7 @@ namespace wgpu_sensor
 
     public: void RemoveSensorEntities(const gz::sim::EntityComponentManager &_ecm);
 
-    private: Mesh* convertSDFModelToWGPU(const sdf::Geometry& geom);
+    public: Mesh* convertSDFModelToWGPU(const sdf::Geometry& geom);
 
     RtScene* rt_scene {nullptr};
     RtRuntime* rt_runtime;
@@ -253,13 +253,6 @@ namespace wgpu_sensor
         sdf::Sensor data = _custom->Data();
         data.SetName(sensorScopedName); // Ensure SDF data has the correct name
 
-        // If the sensor topic is not explicitly set in SDF, generate a default one
-        if (data.Topic().empty())
-        {
-          std::string topic = gz::sim::scopedName(_entity, _ecm) + "/rt_sensor";
-          data.SetTopic(topic);
-        }
-
         // Create an instance of our custom RtSensor
         auto sensor = std::make_shared<rtsensor::RtSensor>();
         if (!sensor->Load(data))
@@ -437,7 +430,6 @@ namespace wgpu_sensor
   void WGPURtSensor::RemoveSensorEntities(
       const gz::sim::EntityComponentManager &_ecm)
   {
-    //GZ_PROFILE("WGPURtSensor::RemoveSensorEntities");
 
     // Iterate over entities that have been removed and clear them from our map
     _ecm.EachRemoved<gz::sim::components::CustomSensor>(


### PR DESCRIPTION
This PR adds the custom sensor implemented in the main plugin.

- Custom sensor implemented in `rtsensor.cc`
- Example: `examples/custom.sdf`
- Also includes some minor knits in `CMakeLists.txt`