### PR TITLE
Mesh-sync fix

### DIFF
--- a/src/rtmanager.hh
+++ b/src/rtmanager.hh
@@ -35,112 +35,112 @@
 
 namespace wgpu_sensor
 {
-class RTManager
-{
+  class RTManager
+  {
 public:
   /// \brief Constructor
-  RTManager();
+    RTManager();
 
   /// \brief Destructor
-  ~RTManager();
+    ~RTManager();
 
   /// \brief Initializes the Rust backend runtime
-  void Initialize();
+    void Initialize();
 
   /// \brief Render job struct
-  struct RenderJob
-  {
+    struct RenderJob
+    {
     /// \brief Sensor Entity ID
-    gz::sim::Entity entityId;
+      gz::sim::Entity entityId;
     /// \brief RT Sensor parameters
-    std::shared_ptr < rtsensor::RtSensor > sensor;
+      std::shared_ptr < rtsensor::RtSensor > sensor;
     /// \brief Sensor World Pose
-    gz::math::Pose3d sensorWorldPose;
+      gz::math::Pose3d sensorWorldPose;
     /// \brief The Update Info
-    gz::sim::UpdateInfo updateInfo;
+      gz::sim::UpdateInfo updateInfo;
     /// \brief Parent frame ID
-    std::string parentFrameId;
-  };
+      std::string parentFrameId;
+    };
 
   /// \brief Adds a render job to the queue
-  void QueueRenderJob(const RenderJob & _job);
+    void QueueRenderJob(const RenderJob & _job);
 
   /// \brief Builds the initial ray-tracing scene from world geometry
-  void BuildScene(const gz::sim::EntityComponentManager & _ecm);
+    void BuildScene(const gz::sim::EntityComponentManager & _ecm);
 
   /// \brief Updates the transforms of all dynamic objects in the scene
-  void UpdateTransforms(const gz::sim::EntityComponentManager & _ecm);
+    void UpdateTransforms(const gz::sim::EntityComponentManager & _ecm);
 
   /// \brief Creates the specific sensor renderer (camera or lidar)
-  void CreateSensorRenderer(
-    const gz::sim::Entity & _entity,
-    const std::shared_ptr < rtsensor::RtSensor > &_sensor);
+    void CreateSensorRenderer(
+      const gz::sim::Entity & _entity,
+      const std::shared_ptr < rtsensor::RtSensor > &_sensor);
 
   /// \brief Removes a sensor renderer when the entity is removed
-  void RemoveSensorRenderer(const gz::sim::Entity & _entity);
+    void RemoveSensorRenderer(const gz::sim::Entity & _entity);
 
   /// \brief Checks if the scene has been built
-  bool IsSceneInitialized() const;
+    bool IsSceneInitialized() const;
 
   /// \brief Mark the scene as dirty, requiring a rebuild
     void MarkSceneDirty();
 
   /// \brief Check if the scene is dirty
-  bool IsSceneDirty() const;
+    bool IsSceneDirty() const;
 
   /// \brief Determines if the scene needs to be rebuilt due to entity changes
-  bool NeedsRebuild(const gz::sim::EntityComponentManager &_ecm) const;
+    bool NeedsRebuild(const gz::sim::EntityComponentManager & _ecm) const;
 
   /// \brief Rebuild the scene (clears and rebuilds from scratch)
-  void RebuildScene(const gz::sim::EntityComponentManager &_ecm);
+    void RebuildScene(const gz::sim::EntityComponentManager & _ecm);
 
-  private:
+private:
     /// \brief Converts SDF geometry to a format the Rust backend can use
-    Mesh * convertSDFModelToWGPU(const sdf::Geometry& geom);
+    Mesh * convertSDFModelToWGPU(const sdf::Geometry & geom);
 
   /// \brief Pointer to the main Rust runtime
-  RtRuntime *rt_runtime {nullptr};
+    RtRuntime *rt_runtime {nullptr};
 
   /// \brief Pointer to the ray-tracing scene on the GPU
-  RtScene *rt_scene {nullptr};
+    RtScene *rt_scene {nullptr};
 
   /// \brief Maps a Gazebo entity to a Rust scene instance for pose updates
-  std::unordered_map < gz::sim::Entity, size_t > gz_entity_to_rt_instance;
+    std::unordered_map < gz::sim::Entity, size_t > gz_entity_to_rt_instance;
 
   /// \brief Maps a sensor entity to its specific Rust depth camera renderer
-  std::unordered_map < gz::sim::Entity, RtDepthCamera * > rt_depth_cameras;
+    std::unordered_map < gz::sim::Entity, RtDepthCamera * > rt_depth_cameras;
 
   /// \brief Maps a sensor entity to its specific Rust LiDAR renderer
-  std::unordered_map < gz::sim::Entity, RtLidar * > rt_lidars;
+    std::unordered_map < gz::sim::Entity, RtLidar * > rt_lidars;
 
   /// \brief Initializes transport node
-  gz::transport::Node node;
+    gz::transport::Node node;
 
   /// \brief Stores transport publishers
-  std::unordered_map < gz::sim::Entity, gz::transport::Node::Publisher > publishers;
+    std::unordered_map < gz::sim::Entity, gz::transport::Node::Publisher > publishers;
 
   /// \brief The main render loop function
-  void RenderLoop();
+    void RenderLoop();
 
   /// \brief The worker thread
-  std::thread workerThread;
+    std::thread workerThread;
 
   /// \brief Queue holds the render jobs
-  std::queue < RenderJob > jobQueue;
+    std::queue < RenderJob > jobQueue;
 
   /// \brief Mutex (lock) protects the queue from being accessed by both threads at once
-  std::mutex queueMutex;
+    std::mutex queueMutex;
 
   /// \brief Signals the worker thread that a new job is ready
-  std::condition_variable condition;
+    std::condition_variable condition;
 
     /// \brief Flag tells the thread to stop when we're done
-    bool stopThread{false};
+    bool stopThread {false};
 
     /// \brief Flag indicating if the scene needs to be rebuilt due to entity changes
     bool sceneDirty = false;
 
     /// \brief Mutex to protect scene data during updates and rendering
     mutable std::shared_mutex sceneMutex;
-};
+  };
 }

--- a/src/wgpu_sensor.cc
+++ b/src/wgpu_sensor.cc
@@ -37,160 +37,161 @@
 namespace wgpu_sensor
 {
 /// \brief A plugin that validates target identification reports.
-class WGPURtSensor:
-public gz::sim::System,
-public gz::sim::ISystemConfigure,
-public gz::sim::ISystemPreUpdate,
-public gz::sim::ISystemPostUpdate
-{
+  class WGPURtSensor:
+  public gz::sim::System,
+  public gz::sim::ISystemConfigure,
+  public gz::sim::ISystemPreUpdate,
+  public gz::sim::ISystemPostUpdate
+  {
   // Documentation inherited
 public: void Configure(
-    const gz::sim::Entity & _entity,
-    const std::shared_ptr < const sdf::Element > &_sdf,
-    gz::sim::EntityComponentManager & _ecm,
-    gz::sim::EventManager & _eventMgr) override;
+      const gz::sim::Entity & _entity,
+      const std::shared_ptr < const sdf::Element > &_sdf,
+      gz::sim::EntityComponentManager & _ecm,
+      gz::sim::EventManager & _eventMgr) override;
 
 public: void PreUpdate(
-    const gz::sim::UpdateInfo & _info,
-    gz::sim::EntityComponentManager & _ecm) override;
+      const gz::sim::UpdateInfo & _info,
+      gz::sim::EntityComponentManager & _ecm) override;
 
   // Documentation inherited
 public: void PostUpdate(
-    const gz::sim::UpdateInfo & _info,
-    const gz::sim::EntityComponentManager & _ecm) override;
+      const gz::sim::UpdateInfo & _info,
+      const gz::sim::EntityComponentManager & _ecm) override;
 
 public: void RemoveSensorEntities(const gz::sim::EntityComponentManager & _ecm);
 
 private:
-  std::unique_ptr < RTManager > rtManager;
-  std::unordered_map < gz::sim::Entity, std::shared_ptr < rtsensor::RtSensor >> entitySensorMap;
+    std::unique_ptr < RTManager > rtManager;
+    std::unordered_map < gz::sim::Entity, std::shared_ptr < rtsensor::RtSensor >> entitySensorMap;
 
-};
+  };
 
-void WGPURtSensor::Configure(
-  const gz::sim::Entity & _entity,
-  const std::shared_ptr < const sdf::Element > &_sdf,
-  gz::sim::EntityComponentManager & _ecm,
-  gz::sim::EventManager & _eventMgr)
-{
-  this->rtManager = std::make_unique < RTManager > ();
-  this->rtManager->Initialize();
-}
-
-void WGPURtSensor::PreUpdate(
-  const gz::sim::UpdateInfo & _info,
-  gz::sim::EntityComponentManager & _ecm)
-{
-  _ecm.EachNew < gz::sim::components::CustomSensor,
-  gz::sim::components::ParentEntity > (
-    [&](const gz::sim::Entity & _entity,
-    const gz::sim::components::CustomSensor *_custom,
-    const gz::sim::components::ParentEntity *_parent)->bool
+  void WGPURtSensor::Configure(
+    const gz::sim::Entity & _entity,
+    const std::shared_ptr < const sdf::Element > &_sdf,
+    gz::sim::EntityComponentManager & _ecm,
+    gz::sim::EventManager & _eventMgr)
   {
-    sdf::Sensor data = _custom->Data();
+    this->rtManager = std::make_unique < RTManager > ();
+    this->rtManager->Initialize();
+  }
 
-    if (data.Topic().empty()) {
-      data.SetTopic(gz::sim::scopedName(_entity, _ecm) + "/rt_sensor");
-    }
-
-    auto sensor = std::make_shared < rtsensor::RtSensor > ();
-
-    if (!sensor->Load(data)) {
-      gzerr << "Failed to load RtSensor for entity [" << _entity << "]" << std::endl;
-      return true;
-    }
-    sensor->SetParentEntity(_parent->Data());
-
-    this->rtManager->CreateSensorRenderer(_entity, sensor);
-
-    this->entitySensorMap[_entity] = sensor;
-
-    return true;
-  });
-
-  _ecm.EachNew<gz::sim::components::Visual, gz::sim::components::Geometry>(
-    [&](const gz::sim::Entity &_entity, const auto*, const auto*) -> bool
+  void WGPURtSensor::PreUpdate(
+    const gz::sim::UpdateInfo & _info,
+    gz::sim::EntityComponentManager & _ecm)
+  {
+    _ecm.EachNew < gz::sim::components::CustomSensor,
+    gz::sim::components::ParentEntity > (
+      [&](const gz::sim::Entity & _entity,
+      const gz::sim::components::CustomSensor *_custom,
+      const gz::sim::components::ParentEntity *_parent)->bool
     {
-      if (this->rtManager->IsSceneInitialized()){
-        gzmsg << "RTManager: New visual entity [" << _entity << "] detected. Marking scene for rebuild." << std::endl;
+      sdf::Sensor data = _custom->Data();
+
+      if (data.Topic().empty()) {
+        data.SetTopic(gz::sim::scopedName(_entity, _ecm) + "/rt_sensor");
+      }
+
+      auto sensor = std::make_shared < rtsensor::RtSensor > ();
+
+      if (!sensor->Load(data)) {
+        gzerr << "Failed to load RtSensor for entity [" << _entity << "]" << std::endl;
+        return true;
+      }
+      sensor->SetParentEntity(_parent->Data());
+
+      this->rtManager->CreateSensorRenderer(_entity, sensor);
+
+      this->entitySensorMap[_entity] = sensor;
+
+      return true;
+    });
+
+    _ecm.EachNew < gz::sim::components::Visual, gz::sim::components::Geometry > (
+      [&](const gz::sim::Entity & _entity, const auto *, const auto *)->bool
+    {
+      if (this->rtManager->IsSceneInitialized()) {
+        gzmsg << "RTManager: New visual entity [" << _entity <<
+          "] detected. Marking scene for rebuild." << std::endl;
         this->rtManager->MarkSceneDirty();
       }
       return true;
     });
 
-  _ecm.EachRemoved<gz::sim::components::Visual>(
-    [&](const gz::sim::Entity &_entity, const auto*) -> bool
+    _ecm.EachRemoved < gz::sim::components::Visual > (
+      [&](const gz::sim::Entity & _entity, const auto *)->bool
     {
-      if (this->rtManager->IsSceneInitialized()){
-        gzmsg << "RTManager: Visual entity [" << _entity << "] removed. Marking scene for rebuild." << std::endl;
+      if (this->rtManager->IsSceneInitialized()) {
+        gzmsg << "RTManager: Visual entity [" << _entity <<
+          "] removed. Marking scene for rebuild." << std::endl;
         this->rtManager->MarkSceneDirty();
       }
       return true;
     });
 
     //this->RemoveSensorEntities(_ecm);
-}
-
-void WGPURtSensor::PostUpdate(
-  const gz::sim::UpdateInfo & _info,
-  const gz::sim::EntityComponentManager & _ecm)
-{
-  using std::chrono::high_resolution_clock;
-  if (_info.paused) {
-    return;
   }
 
-  if (!this->rtManager->IsSceneInitialized()){
-    this->rtManager->BuildScene(_ecm);
-  }
-  else if (this->rtManager->NeedsRebuild(_ecm) || this->rtManager->IsSceneDirty()){
-    this->rtManager->RebuildScene(_ecm);
-  }
-
-  bool shouldUpdate = false;
-
-  for (auto const &[entityId, sensor] : this->entitySensorMap) {
-    auto update_period = std::chrono::duration_cast < std::chrono::steady_clock::duration > (
-      std::chrono::duration < double > (1.0 / sensor->UpdateRate()));
-
-    if ((_info.simTime - sensor->lastUpdateTime) >= update_period) {
-      shouldUpdate = true;
-      sensor->lastUpdateTime = _info.simTime;
-
-      RTManager::RenderJob job;
-      job.entityId = entityId;
-      job.sensor = sensor;
-      job.sensorWorldPose = gz::sim::worldPose(sensor->ParentEntity(), _ecm);
-      job.updateInfo = _info;
-
-      auto parentNameComp = _ecm.Component < gz::sim::components::Name > (sensor->ParentEntity());
-      if(parentNameComp) {
-        job.parentFrameId = parentNameComp->Data();
-      }
-      this->rtManager->QueueRenderJob(job);
-    }
-  }
-
-  if (shouldUpdate) {
-    this->rtManager->UpdateTransforms(_ecm);
-  }
-}
-
-void WGPURtSensor::RemoveSensorEntities(
-  const gz::sim::EntityComponentManager & _ecm)
-{
-  _ecm.EachRemoved < gz::sim::components::CustomSensor > (
-    [this](const gz::sim::Entity & _entity,
-    const auto *)->bool
+  void WGPURtSensor::PostUpdate(
+    const gz::sim::UpdateInfo & _info,
+    const gz::sim::EntityComponentManager & _ecm)
   {
-    if (this->entitySensorMap.count(_entity)) {
-      this->rtManager->RemoveSensorRenderer(_entity);
-      this->entitySensorMap.erase(_entity);
-      gzmsg << "Removed RtSensor for entity [" << _entity << "]." << std::endl;
+    using std::chrono::high_resolution_clock;
+    if (_info.paused) {
+      return;
     }
-    return true;
-  });
-}
+
+    if (!this->rtManager->IsSceneInitialized()) {
+      this->rtManager->BuildScene(_ecm);
+    } else if (this->rtManager->NeedsRebuild(_ecm) || this->rtManager->IsSceneDirty()) {
+      this->rtManager->RebuildScene(_ecm);
+    }
+
+    bool shouldUpdate = false;
+
+    for (auto const &[entityId, sensor] : this->entitySensorMap) {
+      auto update_period = std::chrono::duration_cast < std::chrono::steady_clock::duration > (
+        std::chrono::duration < double > (1.0 / sensor->UpdateRate()));
+
+      if ((_info.simTime - sensor->lastUpdateTime) >= update_period) {
+        shouldUpdate = true;
+        sensor->lastUpdateTime = _info.simTime;
+
+        RTManager::RenderJob job;
+        job.entityId = entityId;
+        job.sensor = sensor;
+        job.sensorWorldPose = gz::sim::worldPose(sensor->ParentEntity(), _ecm);
+        job.updateInfo = _info;
+
+        auto parentNameComp = _ecm.Component < gz::sim::components::Name > (sensor->ParentEntity());
+        if(parentNameComp) {
+          job.parentFrameId = parentNameComp->Data();
+        }
+        this->rtManager->QueueRenderJob(job);
+      }
+    }
+
+    if (shouldUpdate) {
+      this->rtManager->UpdateTransforms(_ecm);
+    }
+  }
+
+  void WGPURtSensor::RemoveSensorEntities(
+    const gz::sim::EntityComponentManager & _ecm)
+  {
+    _ecm.EachRemoved < gz::sim::components::CustomSensor > (
+      [this](const gz::sim::Entity & _entity,
+      const auto *)->bool
+    {
+      if (this->entitySensorMap.count(_entity)) {
+        this->rtManager->RemoveSensorRenderer(_entity);
+        this->entitySensorMap.erase(_entity);
+        gzmsg << "Removed RtSensor for entity [" << _entity << "]." << std::endl;
+      }
+      return true;
+    });
+  }
 }
 
 GZ_ADD_PLUGIN(wgpu_sensor::WGPURtSensor,


### PR DESCRIPTION
This PR resolves Issue #9  by adding robust detection and handling of dynamic scene topology changes (spawn/remove of visuals/models) and by making scene rebuilds thread-safe. Previously, the ray-tracing scene (TLAS) was only built once at startup and subsequent GUI-driven changes were not reflected. A rebuild added mid-render could also race with the render thread, causing wgpu-core to panic with “Tlas[…] does not exist.”
